### PR TITLE
Download remote files to temp directories to prevent collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ If all you need is default Poetry, simply add this to your workflow:
 
 ```yaml
 - name: Install Poetry
-  uses: snok/install-poetry@v1.1.3
+  uses: snok/install-poetry@v1.1.4
 ```
 
 If you want to set Poetry config settings, or install a specific version, you can specify inputs
 
 ```yaml
 - name: Install and configure Poetry
-  uses: snok/install-poetry@v1.1.3
+  uses: snok/install-poetry@v1.1.4
   with:
     version: 1.1.6
     virtualenvs-create: true
@@ -49,7 +49,7 @@ or just to make changes to the Poetry config *after* invoking the action -
 you can do so in a subsequent step, like this
 
 ```yaml
-- uses: snok/install-poetry@v1.1.3
+- uses: snok/install-poetry@v1.1.4
 - run: poetry config experimental.new-installer false
 ```
 
@@ -96,7 +96,7 @@ jobs:
       #  -----  install & configure poetry  -----      
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.3
+        uses: snok/install-poetry@v1.1.4
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -192,7 +192,7 @@ jobs:
       #  -----  install & configure poetry  -----      
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.3
+        uses: snok/install-poetry@v1.1.4
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -259,7 +259,7 @@ jobs:
       #  -----  install & configure poetry  -----      
       #----------------------------------------------
     - name: Install Poetry
-      uses: snok/install-poetry@v1.1.3
+      uses: snok/install-poetry@v1.1.4
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true
@@ -360,7 +360,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.3
+        uses: snok/install-poetry@v1.1.4
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -395,7 +395,7 @@ All of the examples we've added use these Poetry settings
 
 ```yaml
 - name: Install Poetry
-  uses: snok/install-poetry@v1.1.3
+  uses: snok/install-poetry@v1.1.4
   with:
     virtualenvs-create: true
     virtualenvs-in-project: true

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,6 @@ runs:
       run: |
         get_poetry="$(mktemp)"
         curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py --output "$get_poetry"
-        chmod +x "$get_poetry"
         python $get_poetry --yes --version=${{ inputs.version }}
 
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
@@ -38,4 +37,3 @@ runs:
         chmod +x "$install"
         $install ${{ runner.os }} ${{ inputs.virtualenvs-create }} ${{ inputs.virtualenvs-in-project }} ${{ inputs.virtualenvs-path }}
       shell: bash
-

--- a/action.yml
+++ b/action.yml
@@ -26,13 +26,16 @@ runs:
   steps:
     - name: Install and configure Poetry
       run: |
-        curl -O -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py
-        python get-poetry.py --yes --version=${{ inputs.version }}
-        rm get-poetry.py
+        get_poetry="$(mktemp)"
+        curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py --output "$get_poetry"
+        chmod +x "$get_poetry"
+        python $get_poetry --yes --version=${{ inputs.version }}
+
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
-        curl -O -sSL https://raw.githubusercontent.com/snok/install-poetry/main/scripts/v1.1/main.sh
-        chmod +x ./main.sh
-        ./main.sh ${{ runner.os }} ${{ inputs.virtualenvs-create }} ${{ inputs.virtualenvs-in-project }} ${{ inputs.virtualenvs-path }}
-        rm main.sh
+
+        install="$(mktemp)"
+        curl -sSL https://raw.githubusercontent.com/snok/install-poetry/main/scripts/v1.1/main.sh --output "$install"
+        chmod +x "$install"
+        $install ${{ runner.os }} ${{ inputs.virtualenvs-create }} ${{ inputs.virtualenvs-in-project }} ${{ inputs.virtualenvs-path }}
       shell: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "Test"
-version = "1.1.3"
+name = "install-poetry"
+version = "1.1.4"
 description = ""
 authors = ["Sondre Lillebø Gundersen <sondrelg@live.no.com>"]
 maintainers = ["Jonas Krüger Svensson <jonasks@hotmail.com>"]


### PR DESCRIPTION
We initially curled resources into the project root. This takes advantage of the mktemp function to make sure that we never accidentally delete something we're not supposed to because of name collisions. 

Haven't tested if there was a problem to begin with, but this change seems positive regardless.