### PR TITLE
Add support for changes introduced in v1.2.0a1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,11 @@ jobs:
       # matrix:
       #   - os: [ubuntu-latest, ...]
     steps:
-    - id: set-matrix-vars
-      run: |
-        echo "::set-output name=full-matrix::{${{ env.SUPPORTED_POETRY_VERSIONS }},${{ env.SUPPORTED_PYTHON_VERSIONS }},${{ env.SUPPORTED_OPERATING_SYSTEMS }}}"
-        echo "::set-output name=py-os-matrix::{${{ env.SUPPORTED_PYTHON_VERSIONS }},${{ env.SUPPORTED_OPERATING_SYSTEMS }}}"
-        echo "::set-output name=os-matrix::{${{ env.SUPPORTED_OPERATING_SYSTEMS }}}"
+      - id: set-matrix-vars
+        run: |
+          echo "::set-output name=full-matrix::{${{ env.SUPPORTED_POETRY_VERSIONS }},${{ env.SUPPORTED_PYTHON_VERSIONS }},${{ env.SUPPORTED_OPERATING_SYSTEMS }}}"
+          echo "::set-output name=py-os-matrix::{${{ env.SUPPORTED_PYTHON_VERSIONS }},${{ env.SUPPORTED_OPERATING_SYSTEMS }}}"
+          echo "::set-output name=os-matrix::{${{ env.SUPPORTED_OPERATING_SYSTEMS }}}"
 
   # This job makes sure that the install-poetry action works,
   # using the default settings, on all combinations of Python versions,
@@ -139,7 +139,7 @@ jobs:
         id: cached-poetry-dependencies
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-2
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-3
       - run: poetry install
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       - run: |
@@ -170,3 +170,14 @@ jobs:
       - run: |
           source $VENV
           pytest --version
+
+  # Make sure scripts are not deleted.
+  # If we deleted the scripts folder (or subfolders) by accident,
+  # different versions of the action would fail
+  test-scripts-exist:
+    runs-on: ubuntu-latest
+    steps:
+      # v1.1 script loaded in < 1.1.4
+      - uses: snok/install-poetry@v1.1.4
+#      # v1.2 script loaded in > 1.1.4
+#      - uses: snok/install-poetry@v1.1.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on: pull_request
 
 env:
   # JSON variables (used in our strategy/matrix)
-  SUPPORTED_POETRY_VERSIONS: '\"poetry-version\":[\"1.1.0\", \"1.1.2\", \"1.1.4\", \"1.1.5\", \"1.1.6\"]'
+  SUPPORTED_POETRY_VERSIONS: '\"poetry-version\":[\"1.1.0\", \"1.1.6\", \"1.2.0a1\"]'
   SUPPORTED_PYTHON_VERSIONS: '\"python-version\":[\"3.7\", \"3.8\", \"3.9\"]'
   SUPPORTED_OPERATING_SYSTEMS: '\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]'
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ If all you need is default Poetry, simply add this to your workflow:
 
 ```yaml
 - name: Install Poetry
-  uses: snok/install-poetry@v1.1.4
+  uses: snok/install-poetry@v1.1.5
 ```
 
 If you want to set Poetry config settings, or install a specific version, you can specify inputs
 
 ```yaml
 - name: Install and configure Poetry
-  uses: snok/install-poetry@v1.1.4
+  uses: snok/install-poetry@v1.1.5
   with:
     version: 1.1.6
     virtualenvs-create: true
@@ -49,7 +49,7 @@ or just to make changes to the Poetry config *after* invoking the action -
 you can do so in a subsequent step, like this
 
 ```yaml
-- uses: snok/install-poetry@v1.1.4
+- uses: snok/install-poetry@v1.1.5
 - run: poetry config experimental.new-installer false
 ```
 
@@ -96,7 +96,7 @@ jobs:
       #  -----  install & configure poetry  -----      
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.4
+        uses: snok/install-poetry@v1.1.5
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -192,7 +192,7 @@ jobs:
       #  -----  install & configure poetry  -----      
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.4
+        uses: snok/install-poetry@v1.1.5
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -259,7 +259,7 @@ jobs:
       #  -----  install & configure poetry  -----      
       #----------------------------------------------
     - name: Install Poetry
-      uses: snok/install-poetry@v1.1.4
+      uses: snok/install-poetry@v1.1.5
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true
@@ -360,7 +360,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Install Poetry
-        uses: snok/install-poetry@v1.1.4
+        uses: snok/install-poetry@v1.1.5
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -395,7 +395,7 @@ All of the examples we've added use these Poetry settings
 
 ```yaml
 - name: Install Poetry
-  uses: snok/install-poetry@v1.1.4
+  uses: snok/install-poetry@v1.1.5
   with:
     virtualenvs-create: true
     virtualenvs-in-project: true

--- a/action.yml
+++ b/action.yml
@@ -26,14 +26,18 @@ runs:
   steps:
     - name: Install and configure Poetry
       run: |
-        get_poetry="$(mktemp)"
-        curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py --output "$get_poetry"
-        python $get_poetry --yes --version=${{ inputs.version }}
+        installation_script="$(mktemp)"
+        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py --output "$installation_script"
 
-        echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+        config_script="$(mktemp)"
+        curl -sSL https://raw.githubusercontent.com/snok/install-poetry/v1.2/scripts/v1.2/main.sh --output "$config_script"
+        chmod +x "$config_script"
 
-        install="$(mktemp)"
-        curl -sSL https://raw.githubusercontent.com/snok/install-poetry/main/scripts/v1.1/main.sh --output "$install"
-        chmod +x "$install"
-        $install ${{ runner.os }} ${{ inputs.virtualenvs-create }} ${{ inputs.virtualenvs-in-project }} ${{ inputs.virtualenvs-path }}
+        $config_script \
+          ${{ runner.os }} \
+          ${{ inputs.virtualenvs-create }} \
+          ${{ inputs.virtualenvs-in-project }} \
+          ${{ inputs.virtualenvs-path }} \
+          ${{ inputs.version }} \
+          $installation_script
       shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "install-poetry"
-version = "1.1.4"
+version = "1.1.5"
 description = ""
 authors = ["Sondre Lillebø Gundersen <sondrelg@live.no.com>"]
 maintainers = ["Jonas Krüger Svensson <jonasks@hotmail.com>"]

--- a/scripts/v1.2/main.sh
+++ b/scripts/v1.2/main.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Give inputs sensible names
+os=$1
+venv_create=$2
+venv_in_project=$3
+venv_path=$4
+version=$5
+installation_script=$6
+
+# Define OS specific help text
+if [ "$os" == "Windows" ]; then
+  conf="\033[33mConfiguring Poetry for Windows!\033[0m"
+  act="source .venv/scripts/activate"
+  echo "VENV=.venv/scripts/activate" >>"$GITHUB_ENV"
+else
+  conf="\033[33mConfiguring Poetry!\033[0m"
+  act="source .venv/bin/activate"
+  echo "VENV=.venv/bin/activate" >>"$GITHUB_ENV"
+fi
+
+# Echo help texts
+echo -e "\n\n-------------------------------------------------------------------------------\n\n$conf 🎉"
+if [ "$venv_create" == true ] || [ "$venv_create" == "true" ]; then
+  # If user is creating a venv in-project we tell them how to activate venv
+  echo -e "\n\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'\033[0m"
+  echo -e "\n\033[33mIf you're running this in an OS matrix, use 'source \$VENV'\033[0m"
+fi
+if [ "$os" == "Windows" ]; then
+  # If $SHELL isn't some variation of bash, output a yellow-texted warning
+  echo -e "\n\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
+  echo -e "\n\033[33mSee the github action docs for more information and examples.\033[0m"
+fi
+echo -e '\n-------------------------------------------------------------------------------\n'
+
+if [ "$os" == "Windows" ]; then
+  path="C:/Users/runneradmin/AppData/Roaming/Python/Scripts/"
+else
+  path="$HOME/.local/"
+fi
+
+POETRY_HOME=$path python3 $installation_script --yes --version=$version
+
+echo "$path/bin" >>$GITHUB_PATH
+export PATH="$path/bin:$PATH"
+
+if [ "$os" == "Windows" ]; then
+  # Adding to path on windows doesn't immediately take effect
+  # so calling the executable directly here - should be available
+  # in next steps regardless.
+  "$path/bin/poetry.exe" config virtualenvs.create "$venv_create"
+  "$path/bin/poetry.exe" config virtualenvs.in-project "$venv_in_project"
+  "$path/bin/poetry.exe" config virtualenvs.path "$venv_path"
+else
+  poetry config virtualenvs.create "$venv_create"
+  poetry config virtualenvs.in-project "$venv_in_project"
+  poetry config virtualenvs.path "$venv_path"
+fi
+


### PR DESCRIPTION
Poetry just released 1.2.0a1, [here](https://github.com/python-poetry/poetry/releases/tag/1.2.0a1).

From the changes, the most notable for us seems to be that they are deprecating the `get-poetry.py` script. This PR therefore switches to using the `install-poetry.py` script instead.
