### PR TITLE
Make 'latest' the version default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,22 @@ jobs:
           source $VENV
           pytest --version
 
+
+  # Make sure the default version corresponds to 'latest'
+  test-latest-version-when-unspecified:
+    needs: set-env
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Poetry
+        uses: ./
+      # This test will need to change every time poetry releases a new version
+      # If you're submitting a PR and this fails because Poetry release a new version
+      # feel free to update it
+      - run: |
+          source "./assert.sh"
+          assert_in "1.1.8" "$(poetry --version)"
+
   # Make sure scripts are not deleted.
   # If we deleted the scripts folder (or subfolders) by accident,
   # different versions of the action would fail

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you're using this with Windows, see the [Running on Windows](#windows) sectio
 The current default settings are:
 
 ```yaml
-version: 1.1.7
+version: latest
 virtualenvs-create: true
 virtualenvs-in-project: false
 virtualenvs-path: {cache-dir}/virtualenvs

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   version:
     description: "The Poetry version to install"
     required: true
-    default: "1.1.7"
+    default: "latest"
   virtualenvs-create:
     description: "Whether Poetry should create a virtualenv or not"
     required: false
@@ -36,7 +36,12 @@ runs:
         fi
 
         echo -e "\n\033[33mSetting Poetry installation path as $path\033[0m\n"
-        POETRY_HOME=$path python3 $installation_script --yes --version=${{ inputs.version }}
+
+        if [ "${{ inputs.version }}" == "latest" ]; then
+          POETRY_HOME=$path python3 $installation_script --yes
+        else
+          POETRY_HOME=$path python3 $installation_script --yes --version=${{ inputs.version }}
+        fi
 
         echo "$path/bin" >>$GITHUB_PATH
         export PATH="$path/bin:$PATH"


### PR DESCRIPTION
Sets the default value for `version` to be `latest`. If the version input has not been set, we will install Poetry without the `--version` argument, meaning the latest version is installed.

This should remove the need to update the default version every time Poetry makes a release 🙂 