### PR TITLE
Unquote action config arguments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           output=$(poetry config virtualenvs.create)
           echo $output
-          source "./.github/scripts/assert.sh"
+          source .github/scripts/assert.sh
           assert_in "false" "$output"
 
   # Makes sure creating a venv in-project works
@@ -120,7 +120,7 @@ jobs:
           python-version: ${{ env.LATEST_PYTHON }}
       - run: |
           output="$(poetry install)"
-          source "./.github/scripts/assert.sh"
+          source .github/scripts/assert.sh
           echo "$output"
           assert_in "/install-poetry/install-poetry/.venv" "$output"
           source $VENV
@@ -139,7 +139,7 @@ jobs:
       # If you're submitting a PR and this fails because Poetry release a new version
       # feel free to update it
       - run: |
-          source "./.github/scripts/assert.sh"
+          source .github/scripts/assert.sh
           assert_in "1.1.10" "$(poetry --version)"
 
   # Make sure scripts are not deleted.
@@ -162,28 +162,21 @@ jobs:
       - uses: snok/install-poetry@v1.1
       - uses: snok/install-poetry@v1.2
 
-  # Makes sure disabling parallel installs works
-  test-installer-parallel-false:
-    needs: set-env
-    strategy:
-      fail-fast: true
-      matrix: ${{ fromJson(needs.set-env.outputs.os-matrix) }}
-    defaults:
-      run:
-        shell: bash
-    runs-on: ${{ matrix.os }}
+  test-setting-non-default-settings:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: ./
         with:
-          version: ${{ env.LATEST_POETRY }}
+          version: 1.1.7
+          virtualenvs-create: false
+          virtualenvs-in-project: true
+          virtualenvs-path: ~/.cache/virtualenvs
           installer-parallel: false
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.LATEST_PYTHON }}
-      - name: Test parallel option is disabled
-        run: |
-          output=$(poetry config installer.parallel)
-          echo $output
-          source "./.github/scripts/assert.sh"
-          assert_in "false" "$output"
+      - run: |
+          source .github/scripts/assert.sh
+          assert_in  "1.1.7"                            "$(poetry --version)"
+          assert_in  "false"                            "$(poetry config virtualenvs.create)"
+          assert_in  "true"                             "$(poetry config virtualenvs.in-project)"
+          assert_in  "/home/runner/.cache/virtualenvs"  "$(poetry config virtualenvs.path)"
+          assert_in  "false"                            "$(poetry config installer.parallel)"

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
 
         config="$($poetry_ config --list)"
 
-        if echo "$config" | grep -c "installer.parallel"; then
+        if echo "$config" | grep -q -c "installer.parallel"; then
           $poetry_ config installer.parallel "${{ inputs.installer-parallel }}"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -57,9 +57,9 @@ runs:
           poetry_=poetry
         fi
 
-        $poetry_ config virtualenvs.create "${{ inputs.virtualenvs-create }}"
-        $poetry_ config virtualenvs.in-project "${{ inputs.virtualenvs-in-project }}"
-        $poetry_ config virtualenvs.path "${{ inputs.virtualenvs-path }}"
+        $poetry_ config virtualenvs.create ${{ inputs.virtualenvs-create }}
+        $poetry_ config virtualenvs.in-project ${{ inputs.virtualenvs-in-project }}
+        $poetry_ config virtualenvs.path ${{ inputs.virtualenvs-path }}
 
         config="$($poetry_ config --list)"
 


### PR DESCRIPTION
Related to https://github.com/snok/install-poetry/issues/54 and https://github.com/snok/install-poetry/issues/55.

After removing the quoted inputs, I added this test case:

```yaml
  test-setting-non-default-settings:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - uses: ./
        with:
          version: 1.1.7
          virtualenvs-create: false
          virtualenvs-in-project: true
          virtualenvs-path: ~/.cache/virtualenvs
          installer-parallel: false
      - run: |
          source .github/scripts/assert.sh
          assert_in  "1.1.7"                            "$(poetry --version)"
          assert_in  "false"                            "$(poetry config virtualenvs.create)"
          assert_in  "true"                             "$(poetry config virtualenvs.in-project)"
          assert_in  "/home/runner/.cache/virtualenvs"  "$(poetry config virtualenvs.path)"
          assert_in  "false"                            "$(poetry config installer.parallel)"
```

As far as I can tell, this shows definitively that, the tilde is now expanded, and every single input is set as expected.

Relevant workflow run: https://github.com/snok/install-poetry/runs/3771572930?check_suite_focus=true
