### PR TITLE
Accept additional options to pass to poetry 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,7 @@ jobs:
       # feel free to update it
       - run: |
           source .github/scripts/assert.sh
-          assert_in "1.1.10" "$(poetry --version)"
+          assert_in "1.1.11" "$(poetry --version)"
 
   # Make sure scripts are not deleted.
   # If we deleted the scripts folder (or subfolders) by accident,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,7 +181,7 @@ jobs:
           assert_in  "/home/runner/.cache/virtualenvs"  "$(poetry config virtualenvs.path)"
           assert_in  "false"                            "$(poetry config installer.parallel)"
 
-  test-additional-options-version-unspecified:
+  test-installation-arguments-version-unspecified:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -190,19 +190,19 @@ jobs:
         # If you're submitting a PR and this fails because Poetry release a new version
         # feel free to update it
         with:
-          additional-options: --git https://github.com/python-poetry/poetry.git@69bd6820e320f84900103fdf867e24b355d6aa5d
+          installation-arguments: --git https://github.com/python-poetry/poetry.git@69bd6820e320f84900103fdf867e24b355d6aa5d
       - run: |
           source .github/scripts/assert.sh
           assert_in "1.1.9" "$(poetry --version)"
 
-  test-additional-options-version-specified:
+  test-installation-arguments-version-specified:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: ./
         with:
           version: 1.1.7
-          additional-options: --git https://github.com/python-poetry/poetry.git@69bd6820e320f84900103fdf867e24b355d6aa5d
+          installation-arguments: --git https://github.com/python-poetry/poetry.git@69bd6820e320f84900103fdf867e24b355d6aa5d
       - run: |
           source .github/scripts/assert.sh
           assert_in "1.1.9" "$(poetry --version)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,3 +180,29 @@ jobs:
           assert_in  "true"                             "$(poetry config virtualenvs.in-project)"
           assert_in  "/home/runner/.cache/virtualenvs"  "$(poetry config virtualenvs.path)"
           assert_in  "false"                            "$(poetry config installer.parallel)"
+
+  test-additional-options-version-unspecified:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        # This test will need to change every time poetry releases a new version
+        # If you're submitting a PR and this fails because Poetry release a new version
+        # feel free to update it
+        with:
+          additional-options: --git https://github.com/python-poetry/poetry.git@master
+      - run: |
+          source .github/scripts/assert.sh
+          assert_in "1.1.11"                            "$(poetry --version)"
+
+  test-additional-options-version-specified:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          version: 1.1.7
+          additional-options: --force
+      - run: |
+          source .github/scripts/assert.sh
+          assert_in "1.1.7"                            "$(poetry --version)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,7 +193,7 @@ jobs:
           additional-options: --git https://github.com/python-poetry/poetry.git@master
       - run: |
           source .github/scripts/assert.sh
-          assert_in "1.1.11"                            "$(poetry --version)"
+          assert_in "1.1.9"                            "$(poetry --version)"
 
   test-additional-options-version-specified:
     runs-on: ubuntu-latest
@@ -205,4 +205,4 @@ jobs:
           additional-options: --force
       - run: |
           source .github/scripts/assert.sh
-          assert_in "1.1.7"                            "$(poetry --version)"
+          assert_in "1.1.9"                            "$(poetry --version)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,7 +193,7 @@ jobs:
           additional-options: --git https://github.com/python-poetry/poetry.git@69bd6820e320f84900103fdf867e24b355d6aa5d
       - run: |
           source .github/scripts/assert.sh
-          assert_in "1.1.9"                            "$(poetry --version)"
+          assert_in "1.1.9" "$(poetry --version)"
 
   test-additional-options-version-specified:
     runs-on: ubuntu-latest
@@ -205,4 +205,4 @@ jobs:
           additional-options: --git https://github.com/python-poetry/poetry.git@69bd6820e320f84900103fdf867e24b355d6aa5d
       - run: |
           source .github/scripts/assert.sh
-          assert_in "1.1.9"                            "$(poetry --version)"
+          assert_in "1.1.9" "$(poetry --version)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,9 +186,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ./
-        # This test will need to change every time poetry releases a new version
-        # If you're submitting a PR and this fails because Poetry release a new version
-        # feel free to update it
         with:
           installation-arguments: --git https://github.com/python-poetry/poetry.git@69bd6820e320f84900103fdf867e24b355d6aa5d
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
         # If you're submitting a PR and this fails because Poetry release a new version
         # feel free to update it
         with:
-          additional-options: --git https://github.com/python-poetry/poetry.git@master
+          additional-options: --git https://github.com/python-poetry/poetry.git@69bd6820e320f84900103fdf867e24b355d6aa5d
       - run: |
           source .github/scripts/assert.sh
           assert_in "1.1.9"                            "$(poetry --version)"
@@ -202,7 +202,7 @@ jobs:
       - uses: ./
         with:
           version: 1.1.7
-          additional-options: --force
+          additional-options: --git https://github.com/python-poetry/poetry.git@69bd6820e320f84900103fdf867e24b355d6aa5d
       - run: |
           source .github/scripts/assert.sh
           assert_in "1.1.9"                            "$(poetry --version)"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ If all you need is default Poetry, simply add this to your workflow:
 ```yaml
 - name: Install Poetry
   uses: snok/install-poetry@v1
+  with:
+    installation-arguments: --force
 ```
 
 If you want to set Poetry config settings, or install a specific version, you can specify inputs:
@@ -29,6 +31,7 @@ If you want to set Poetry config settings, or install a specific version, you ca
     virtualenvs-in-project: false
     virtualenvs-path: ~/my-custom-path
     installer-parallel: true
+    installation-arguments: --force
 ```
 
 The action is fully tested for MacOS and Ubuntu runners, on Poetry versions >= 1.1.0.
@@ -45,6 +48,16 @@ virtualenvs-create: true
 virtualenvs-in-project: false
 virtualenvs-path: {cache-dir}/virtualenvs
 installer-parallel: true
+```
+
+You can specify installation arguments directly to the poetry installer using the installation-arguments in the following
+way.
+
+```yaml
+- name: Install and configure Poetry
+  uses: snok/install-poetry@v1
+  with:
+    installation-arguments: --git https://github.com/python-poetry/poetry.git@69bd6820e320f84900103fdf867e24b355d6aa5d
 ```
 
 If you want to make further config changes - e.g., to change one of the `experimental` Poetry config settings, or just

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ If all you need is default Poetry, simply add this to your workflow:
 ```yaml
 - name: Install Poetry
   uses: snok/install-poetry@v1
-  with:
-    installation-arguments: --force
 ```
 
 If you want to set Poetry config settings, or install a specific version, you can specify inputs:
@@ -31,12 +29,11 @@ If you want to set Poetry config settings, or install a specific version, you ca
     virtualenvs-in-project: false
     virtualenvs-path: ~/my-custom-path
     installer-parallel: true
-    installation-arguments: --force
 ```
 
-The action is fully tested for MacOS and Ubuntu runners, on Poetry versions >= 1.1.0.
+If you need to pass extra arguments to the installer script, you can specify these with `installation-arguments`.
 
-If you're using this with Windows, see the [Running on Windows](#windows) section.
+The action is fully tested for MacOS and Ubuntu runners, on Poetry versions >= 1.1.0. If you're using this with Windows, see the [Running on Windows](#windows) section.
 
 ## Defaults
 
@@ -51,7 +48,7 @@ installer-parallel: true
 ```
 
 You can specify installation arguments directly to the poetry installer using the installation-arguments in the following
-way.
+way:
 
 ```yaml
 - name: Install and configure Poetry
@@ -76,7 +73,7 @@ This section contains a collection of workflow examples to try and help
 - Demonstrate how to implement caching for performance improvements
 - Clarify the implications of different settings
 
-Some of the examples are a bit long, so here are some links
+Some examples are a bit long, so here are some links
 
 - [Testing](#testing)
 - [Testing (using an OS matrix)](#testing-using-a-matrix)

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,8 @@ inputs:
     description: "Whether to install many packages at once or one by one. This can fix PyPI DNS resolution errors, but also slows down the installation"
     required: false
     default: "true"
-  other-options:
-    description: "Other options to pass directly to poetry. For example --force."
+  installation-arguments:
+    description: "Arguments passed directly to the Poetry installation script. For example --force."
     required: false
 runs:
   using: "composite"
@@ -46,9 +46,9 @@ runs:
         echo -e "\033[33mInstalling Poetry 👷\033[0m\n"
 
         if [ "${{ inputs.version }}" == "latest" ]; then
-          POETRY_HOME=$path python3 $installation_script --yes ${{ inputs.other_options}}
+          POETRY_HOME=$path python3 $installation_script --yes ${{ inputs.installation-arguments}}
         else
-          POETRY_HOME=$path python3 $installation_script --yes --version=${{ inputs.version }} ${{ inputs.other_options}}
+          POETRY_HOME=$path python3 $installation_script --yes --version=${{ inputs.version }} ${{ inputs.installation-arguments}}
         fi
 
         echo "$path/bin" >>$GITHUB_PATH

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
     description: "Whether to install many packages at once or one by one. This can fix PyPI DNS resolution errors, but also slows down the installation"
     required: false
     default: "true"
+  other-options:
+    description: "Other options to pass directly to poetry. For example --force."
+    required: false
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
         echo -e "\033[33mInstalling Poetry 👷\033[0m\n"
 
         if [ "${{ inputs.version }}" == "latest" ]; then
-          POETRY_HOME=$path python3 $installation_script --yes
+          POETRY_HOME=$path python3 $installation_script --yes ${{ inputs.other_options}}
         else
           POETRY_HOME=$path python3 $installation_script --yes --version=${{ inputs.version }}
         fi

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
         if [ "${{ inputs.version }}" == "latest" ]; then
           POETRY_HOME=$path python3 $installation_script --yes ${{ inputs.other_options}}
         else
-          POETRY_HOME=$path python3 $installation_script --yes --version=${{ inputs.version }}
+          POETRY_HOME=$path python3 $installation_script --yes --version=${{ inputs.version }} ${{ inputs.other_options}}
         fi
 
         echo "$path/bin" >>$GITHUB_PATH


### PR DESCRIPTION
Accept additional options from the user that are directly passed to poetry when installing it.

This will allow to install directly from github or use any of the other options accepted by [poetry's installer script](https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py).

This closes #59.