### PR TITLE
Remove duplicate pre-commit-hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: mixed-line-ending
-      - id: trailing-whitespace
   - repo: https://github.com/sirosen/check-jsonschema
     rev: '0.4.1'
     hooks:


### PR DESCRIPTION
Thank you for creating this action.
Looking over it I realized that one pre-commit-hook is defined two times.