### PR TITLE
WIP: Add ability to install plugins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -215,3 +215,33 @@ jobs:
           source .github/scripts/assert.sh
           poetry plugin show
           assert_in "poetry-version-plugin" "$(poetry plugin show)"
+
+  test-plugins-comma-delimited:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          version: 1.2.0a2
+          plugins: poetry-version-plugin, poetry-export-plugin
+      - run: |
+          source .github/scripts/assert.sh
+          poetry plugin show
+          assert_in "poetry-version-plugin" "$(poetry plugin show)"
+          assert_in "poetry-export-plugin" "$(poetry plugin show)"
+
+  test-plugins-whitespace-delimited:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          version: 1.2.0a2
+          plugins: |
+            poetry-version-plugin
+            poetry-export-plugin
+      - run: |
+          source .github/scripts/assert.sh
+          poetry plugin show
+          assert_in "poetry-version-plugin" "$(poetry plugin show)"
+          assert_in "poetry-export-plugin" "$(poetry plugin show)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,3 +202,16 @@ jobs:
       - run: |
           source .github/scripts/assert.sh
           assert_in "1.1.9" "$(poetry --version)"
+
+  test-plugin-installation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          version: 1.2.0a2
+          plugins: poetry-version-plugin
+      - run: |
+          source .github/scripts/assert.sh
+          poetry plugin show
+          assert_in "poetry-version-plugin" "$(poetry plugin show)"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This section contains a collection of workflow examples to try and help
 - Demonstrate how to implement caching for performance improvements
 - Clarify the implications of different settings
 
-Some examples are a bit long, so here are some links
+Some examples are a bit long, so here are some links:
 
 - [Testing](#testing)
 - [Testing (using an OS matrix)](#testing-using-a-matrix)
@@ -81,6 +81,7 @@ Some examples are a bit long, so here are some links
 - [Running on Windows](#running-on-windows)
 - [Virtualenv variations](#virtualenv-variations)
 - [Caching the Poetry installation](#caching-the-poetry-installation)
+- [Installing Poetry Plugins](#installing-poetry-plugins)
 
 #### Testing
 
@@ -325,6 +326,7 @@ Running this action on Windows is supported, but two things are important to not
       run:
         shell: bash
     ```
+
 2. If you are running an OS matrix, and want to activate your venv `in-project`
    you have to deal with different folder structures on different operating systems. To make this work, you *can* do
    this
@@ -499,6 +501,37 @@ jobs:
 ```
 
 The directory to cache will depend on the operating system of the runner.
+
+#### Installing Poetry Plugins
+
+With Poetry 1.2 or later, you can use this action to install plugins:
+
+```yaml
+- uses: snok/install-poetry@v1
+  with:
+    version: 1.2.0a2
+    plugins: poetry-plugin-a
+```
+
+You can use a comma delimited list:
+
+```yaml
+- uses: snok/install-poetry@v1
+  with:
+    version: 1.2.0a2
+    plugins: poetry-plugin-a, poetry-plugin-b
+```
+
+or a whitespace delimited list:
+
+```yaml
+- uses: snok/install-poetry@v1
+  with:
+    version: 1.2.0a2
+    plugins: |
+        poetry-plugin-a
+        poetry-plugin-b
+```
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   installation-arguments:
     description: "Arguments passed directly to the Poetry installation script. For example --force."
     required: false
+  plugins:
+    description: "Comma- or whitespace-delimited list of poetry plugins to install. Requires Poetry>=1.2"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -41,3 +44,4 @@ runs:
         VIRTUALENVS_PATH:       ${{ inputs.virtualenvs-path }}
         INSTALLER_PARALLEL:     ${{ inputs.installer-parallel }}
         INSTALLATION_ARGUMENTS: ${{ inputs.installation-arguments }}
+        POETRY_PLUGINS:         ${{ inputs.plugins }}

--- a/main.sh
+++ b/main.sh
@@ -34,6 +34,14 @@ $poetry_ config virtualenvs.create ${VIRTUALENVS_CREATE}
 $poetry_ config virtualenvs.in-project ${VIRTUALENVS_IN_PROJECT}
 $poetry_ config virtualenvs.path ${VIRTUALENVS_PATH}
 
+# Install plugins from whitespace or commas-delimited list
+read -r -a plugins <<< "$(echo "$POETRY_PLUGINS" | tr "," " ")"
+for plugin in "${plugins[@]}"
+do
+    echo "Installing plugin: $plugin"
+    $poetry_ plugin add "$plugin"
+done 
+
 config="$($poetry_ config --list)"
 
 if echo "$config" | grep -q -c "installer.parallel"; then

--- a/main.sh
+++ b/main.sh
@@ -35,11 +35,7 @@ $poetry_ config virtualenvs.in-project ${VIRTUALENVS_IN_PROJECT}
 $poetry_ config virtualenvs.path ${VIRTUALENVS_PATH}
 
 # Parse plugin array from comma- or whitespace-delimited string
-echo "AAA all plugins: $POETRY_PLUGINS"
-read -r -a plugins <<< "$(echo "$POETRY_PLUGINS" | tr "," " ")"
-echo "** My array:" "${plugins[@]}"
-echo "** Number of elements in the array:" "${#plugins[@]}"
-
+read -r -d "" -a plugins <<< "$(echo "$POETRY_PLUGINS" | tr "," " ")"
 if [ ${#plugins[@]} -gt 0 ]; then
 
     # Ensure poetry version >= 1.2

--- a/main.sh
+++ b/main.sh
@@ -35,7 +35,11 @@ $poetry_ config virtualenvs.in-project ${VIRTUALENVS_IN_PROJECT}
 $poetry_ config virtualenvs.path ${VIRTUALENVS_PATH}
 
 # Parse plugin array from comma- or whitespace-delimited string
+echo "AAA all plugins: $POETRY_PLUGINS"
 read -r -a plugins <<< "$(echo "$POETRY_PLUGINS" | tr "," " ")"
+echo "** My array:" "${plugins[@]}"
+echo "** Number of elements in the array:" "${#plugins[@]}"
+
 if [ ${#plugins[@]} -gt 0 ]; then
 
     # Ensure poetry version >= 1.2
@@ -51,7 +55,7 @@ if [ ${#plugins[@]} -gt 0 ]; then
     for plugin in "${plugins[@]}"
     do
         echo "Installing plugin: $plugin"
-        $poetry_ plugin add "$plugin"
+        $poetry_ plugin add "$plugin" || exit 1
     done 
 fi
 

--- a/main.sh
+++ b/main.sh
@@ -34,7 +34,7 @@ $poetry_ config virtualenvs.create ${VIRTUALENVS_CREATE}
 $poetry_ config virtualenvs.in-project ${VIRTUALENVS_IN_PROJECT}
 $poetry_ config virtualenvs.path ${VIRTUALENVS_PATH}
 
-# Parse plugin array from comma- or whitespace-delimited string
+# Parse plugin array from string, handle comma, whitespace or newline delimiters
 read -r -d "" -a plugins <<< "$(echo "$POETRY_PLUGINS" | tr "," " ")"
 if [ ${#plugins[@]} -gt 0 ]; then
 
@@ -42,17 +42,14 @@ if [ ${#plugins[@]} -gt 0 ]; then
     # Simplistic version comparison, will need to be updated if Poetry 2.X is released
     major=${VERSION:0:1}
     minor=${VERSION:2:1}
-    if [ $major -lt 1 ] || [ $minor -lt 2 ]; then
+    if [ "$major" -lt 1 ] || [ "$minor" -lt 2 ]; then
         echo "Use of plugins requires Poetry version >= 1.2"
         exit 1
     fi
 
     # Install plugins
-    for plugin in "${plugins[@]}"
-    do
-        echo "Installing plugin: $plugin"
-        $poetry_ plugin add "$plugin" || exit 1
-    done 
+    echo "Installing plugins: " "${plugins[@]}"
+    $poetry_ plugin add "${plugins[@]}" || exit 1
 fi
 
 config="$($poetry_ config --list)"

--- a/main.sh
+++ b/main.sh
@@ -34,13 +34,26 @@ $poetry_ config virtualenvs.create ${VIRTUALENVS_CREATE}
 $poetry_ config virtualenvs.in-project ${VIRTUALENVS_IN_PROJECT}
 $poetry_ config virtualenvs.path ${VIRTUALENVS_PATH}
 
-# Install plugins from whitespace or commas-delimited list
+# Parse plugin array from comma- or whitespace-delimited string
 read -r -a plugins <<< "$(echo "$POETRY_PLUGINS" | tr "," " ")"
-for plugin in "${plugins[@]}"
-do
-    echo "Installing plugin: $plugin"
-    $poetry_ plugin add "$plugin"
-done 
+if [ ${#plugins[@]} -gt 0 ]; then
+
+    # Ensure poetry version >= 1.2
+    # Simplistic version comparison, will need to be updated if Poetry 2.X is released
+    major=${VERSION:0:1}
+    minor=${VERSION:2:1}
+    if [ $major -lt 1 ] || [ $minor -lt 2 ]; then
+        echo "Use of plugins requires Poetry version >= 1.2"
+        exit 1
+    fi
+
+    # Install plugins
+    for plugin in "${plugins[@]}"
+    do
+        echo "Installing plugin: $plugin"
+        $poetry_ plugin add "$plugin"
+    done 
+fi
 
 config="$($poetry_ config --list)"
 


### PR DESCRIPTION
Closes #53 

Adds ability to install plugins with:

```yaml
- uses: snok/install-poetry@v1
  with:
    version: 1.2.0a2
    plugins: poetry-plugin-a, poetry-plugin-b
```

Might be worth adding a check that the Poetry version is at least 1.2 before trying to install plugins? I also note that version is not released yet, so possibly the syntax may change in future.