### PR TITLE
Lint shell scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
 [*.sh]
 indent_style = space
-indent_size = 4
+indent_size = 2

--- a/.github/scripts/assert.sh
+++ b/.github/scripts/assert.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 assert_in_one() {
     local option1="$1"
     local option2="$2"

--- a/.github/scripts/assert.sh
+++ b/.github/scripts/assert.sh
@@ -3,30 +3,30 @@
 set -eo pipefail
 
 assert_in_one() {
-    local option1="$1"
-    local option2="$2"
-    local option3="$3"
-    local long="$4"
+  local option1="$1"
+  local option2="$2"
+  local option3="$3"
+  local long="$4"
 
-    if [[ "$long" == *"$option1"* || "$long" == *"$option2"* || "$long" == *"$option3"* ]]; then
-        echo "assertion succeeded: one of the options were found in ${long}"
-        return 0
-    else
-        echo "assertion failed: none of the options were found in ${long}"
-        echo -e "options:\n- $option1\n- $option2\n- $option3"
-        return 1
-    fi
+  if [[ "$long" == *"$option1"* || "$long" == *"$option2"* || "$long" == *"$option3"* ]]; then
+    echo "assertion succeeded: one of the options were found in ${long}"
+    return 0
+  else
+    echo "assertion failed: none of the options were found in ${long}"
+    echo -e "options:\n- $option1\n- $option2\n- $option3"
+    return 1
+  fi
 }
 assert_in() {
-    local short="$1"
-    local long="$2"
-    # On windows paths use \ and unix uses /, so here we standardize
-    long="${long//\\//}"
-    if [[ "$long" == *"$short"* ]]; then
-        echo "assertion succeeded: ${short} was found in ${long}"
-        return 0
-    else
-        echo "assertion failed: ${short} not found in ${long}"
-        return 1
-    fi
+  local short="$1"
+  local long="$2"
+  # On windows paths use \ and unix uses /, so here we standardize
+  long="${long//\\//}"
+  if [[ "$long" == *"$short"* ]]; then
+    echo "assertion succeeded: ${short} was found in ${long}"
+    return 0
+  else
+    echo "assertion failed: ${short} not found in ${long}"
+    return 1
+  fi
 }

--- a/.github/scripts/assert.sh
+++ b/.github/scripts/assert.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
 
 assert_in_one() {
-  local option1="$1"
-  local option2="$2"
-  local option3="$3"
-  local long="$4"
+    local option1="$1"
+    local option2="$2"
+    local option3="$3"
+    local long="$4"
 
-  if [[ "$long" == *"$option1"* || "$long" == *"$option2"* || "$long" == *"$option3"* ]]; then
-    echo "assertion succeeded: one of the options were found in ${long}"
-    return 0
-  else
-    echo "assertion failed: none of the options were found in ${long}"
-    echo -e "options:\n- $option1\n- $option2\n- $option3"
-    return 1
-  fi
+    if [[ "$long" == *"$option1"* || "$long" == *"$option2"* || "$long" == *"$option3"* ]]; then
+        echo "assertion succeeded: one of the options were found in ${long}"
+        return 0
+    else
+        echo "assertion failed: none of the options were found in ${long}"
+        echo -e "options:\n- $option1\n- $option2\n- $option3"
+        return 1
+    fi
 }
 assert_in() {
-  local short="$1"
-  local long="$2"
-  # On windows paths use \ and unix uses /, so here we standardize
-  long="${long//\\//}"
-  if [[ "$long" == *"$short"* ]]; then
-    echo "assertion succeeded: ${short} was found in ${long}"
-    return 0
-  else
-    echo "assertion failed: ${short} not found in ${long}"
-    return 1
-  fi
+    local short="$1"
+    local long="$2"
+    # On windows paths use \ and unix uses /, so here we standardize
+    long="${long//\\//}"
+    if [[ "$long" == *"$short"* ]]; then
+        echo "assertion succeeded: ${short} was found in ${long}"
+        return 0
+    else
+        echo "assertion failed: ${short} not found in ${long}"
+        return 1
+    fi
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,10 @@ repos:
     hooks:
       - id: check-github-actions
       - id: check-github-workflows
+
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: shfmt
+      - id: shellcheck
+        files: 'main\/.sh'

--- a/main.sh
+++ b/main.sh
@@ -6,30 +6,30 @@ installation_script="$(mktemp)"
 curl -sSL https://install.python-poetry.org/ --output "$installation_script"
 
 if [ "${RUNNER_OS}" == "Windows" ]; then
-    path="C:/Users/runneradmin/AppData/Roaming/Python/Scripts"
+  path="C:/Users/runneradmin/AppData/Roaming/Python/Scripts"
 else
-    path="$HOME/.local"
+  path="$HOME/.local"
 fi
 
 echo -e "\n\033[33mSetting Poetry installation path as $path\033[0m\n"
 echo -e "\033[33mInstalling Poetry 👷\033[0m\n"
 
 if [ "${VERSION}" == "latest" ]; then
-    # Note: If we quote installation arguments, the call below fails
-    # shellcheck disable=SC2086
-    POETRY_HOME=$path python3 "${installation_script}" --yes ${INSTALLATION_ARGUMENTS}
+  # Note: If we quote installation arguments, the call below fails
+  # shellcheck disable=SC2086
+  POETRY_HOME=$path python3 "${installation_script}" --yes ${INSTALLATION_ARGUMENTS}
 else
-    # shellcheck disable=SC2086
-    POETRY_HOME=$path python3 "${installation_script}" --yes --version="${VERSION}" ${INSTALLATION_ARGUMENTS}
+  # shellcheck disable=SC2086
+  POETRY_HOME=$path python3 "${installation_script}" --yes --version="${VERSION}" ${INSTALLATION_ARGUMENTS}
 fi
 
 echo "$path/bin" >>"$GITHUB_PATH"
 export PATH="$path/bin:$PATH"
 
 if [ "${RUNNER_OS}" == "Windows" ]; then
-    poetry_="$path/bin/poetry.exe"
+  poetry_="$path/bin/poetry.exe"
 else
-    poetry_=poetry
+  poetry_=poetry
 fi
 
 # Expand any "~" in VIRTUALENVS_PATH
@@ -42,24 +42,24 @@ VIRTUALENVS_PATH="${VIRTUALENVS_PATH/#\~/$HOME}"
 config="$("$poetry_" config --list)"
 
 if echo "$config" | grep -q -c "installer.parallel"; then
-    "$poetry_" config installer.parallel "${INSTALLER_PARALLEL}"
+  "$poetry_" config installer.parallel "${INSTALLER_PARALLEL}"
 fi
 
 if [ "${RUNNER_OS}" == "Windows" ]; then
-    act="source .venv/scripts/activate"
-    echo "VENV=.venv/scripts/activate" >>"$GITHUB_ENV"
+  act="source .venv/scripts/activate"
+  echo "VENV=.venv/scripts/activate" >>"$GITHUB_ENV"
 else
-    act="source .venv/bin/activate"
-    echo "VENV=.venv/bin/activate" >>"$GITHUB_ENV"
+  act="source .venv/bin/activate"
+  echo "VENV=.venv/bin/activate" >>"$GITHUB_ENV"
 fi
 
 echo -e "\n\033[33mInstallation completed. Configuring settings 🛠\033[0m"
 echo -e "\n\033[33mDone ✅\033[0m"
 
 if [ "${VIRTUALENVS_CREATE}" == true ] || [ "${VIRTUALENVS_CREATE}" == "true" ]; then
-    echo -e "\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'. If you're running this in an OS matrix, you can use 'source \$VENV' instead, as an OS agnostic option\033[0m"
+  echo -e "\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'. If you're running this in an OS matrix, you can use 'source \$VENV' instead, as an OS agnostic option\033[0m"
 fi
 if [ "${RUNNER_OS}" == "Windows" ]; then
-    echo -e "\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
-    echo -e "\n\033[33mSee the github action docs for more information and examples.\033[0m"
+  echo -e "\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
+  echo -e "\n\033[33mSee the github action docs for more information and examples.\033[0m"
 fi

--- a/main.sh
+++ b/main.sh
@@ -13,9 +13,12 @@ echo -e "\n\033[33mSetting Poetry installation path as $path\033[0m\n"
 echo -e "\033[33mInstalling Poetry 👷\033[0m\n"
 
 if [ "${VERSION}" == "latest" ]; then
-    POETRY_HOME=$path python3 $installation_script --yes ${INSTALLATION_ARGUMENTS}
+    # Note: If we quote installation arguments, the call below fails
+    # shellcheck disable=SC2086
+    POETRY_HOME=$path python3 "${installation_script}" --yes ${INSTALLATION_ARGUMENTS}
 else
-    POETRY_HOME=$path python3 $installation_script --yes --version=${VERSION} ${INSTALLATION_ARGUMENTS}
+    # shellcheck disable=SC2086
+    POETRY_HOME=$path python3 "${installation_script}" --yes --version="${VERSION}" ${INSTALLATION_ARGUMENTS}
 fi
 
 echo "$path/bin" >>"$GITHUB_PATH"
@@ -30,14 +33,14 @@ fi
 # Expand any "~" in VIRTUALENVS_PATH
 VIRTUALENVS_PATH="${VIRTUALENVS_PATH/#\~/$HOME}"
 
-$poetry_ config virtualenvs.create ${VIRTUALENVS_CREATE}
-$poetry_ config virtualenvs.in-project ${VIRTUALENVS_IN_PROJECT}
-$poetry_ config virtualenvs.path ${VIRTUALENVS_PATH}
+"$poetry_" config virtualenvs.create "${VIRTUALENVS_CREATE}"
+"$poetry_" config virtualenvs.in-project "${VIRTUALENVS_IN_PROJECT}"
+"$poetry_" config virtualenvs.path "${VIRTUALENVS_PATH}"
 
-config="$($poetry_ config --list)"
+config="$("$poetry_" config --list)"
 
 if echo "$config" | grep -q -c "installer.parallel"; then
-    $poetry_ config installer.parallel "${INSTALLER_PARALLEL}"
+    "$poetry_" config installer.parallel "${INSTALLER_PARALLEL}"
 fi
 
 if [ "${RUNNER_OS}" == "Windows" ]; then

--- a/main.sh
+++ b/main.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 installation_script="$(mktemp)"
 curl -sSL https://install.python-poetry.org/ --output "$installation_script"
 
 if [ "${RUNNER_OS}" == "Windows" ]; then
     path="C:/Users/runneradmin/AppData/Roaming/Python/Scripts"
 else
-    path="$HOME/.local/"
+    path="$HOME/.local"
 fi
 
 echo -e "\n\033[33mSetting Poetry installation path as $path\033[0m\n"

--- a/scripts/v1.1/main.sh
+++ b/scripts/v1.1/main.sh
@@ -8,38 +8,38 @@ venv_path=$4
 
 # Define OS specific help text
 if [ "$os" == "Windows" ]; then
-    conf="\033[33mConfiguring Poetry for Windows!\033[0m"
-    act="source .venv/scripts/activate"
-    echo "VENV=.venv/scripts/activate" >>"$GITHUB_ENV"
+  conf="\033[33mConfiguring Poetry for Windows!\033[0m"
+  act="source .venv/scripts/activate"
+  echo "VENV=.venv/scripts/activate" >>"$GITHUB_ENV"
 else
-    conf="\033[33mConfiguring Poetry!\033[0m"
-    act="source .venv/bin/activate"
-    echo "VENV=.venv/bin/activate" >>"$GITHUB_ENV"
+  conf="\033[33mConfiguring Poetry!\033[0m"
+  act="source .venv/bin/activate"
+  echo "VENV=.venv/bin/activate" >>"$GITHUB_ENV"
 fi
 
 # Echo help texts
 echo -e "\n\n-------------------------------------------------------------------------------\n\n$conf 🎉"
 if [ "$venv_create" == true ] || [ "$venv_create" == "true" ]; then
-    # If user is creating a venv in-project we tell them how to activate venv
-    echo -e "\n\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'\033[0m"
-    echo -e "\n\033[33mIf you're running this in an OS matrix, use 'source \$VENV'\033[0m"
+  # If user is creating a venv in-project we tell them how to activate venv
+  echo -e "\n\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'\033[0m"
+  echo -e "\n\033[33mIf you're running this in an OS matrix, use 'source \$VENV'\033[0m"
 fi
 if [ "$os" == "Windows" ]; then
-    # If $SHELL isn't some variation of bash, output a yellow-texted warning
-    echo -e "\n\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
-    echo -e "\n\033[33mSee the package docs for more information and examples.\033[0m"
+  # If $SHELL isn't some variation of bash, output a yellow-texted warning
+  echo -e "\n\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
+  echo -e "\n\033[33mSee the package docs for more information and examples.\033[0m"
 fi
 echo -e '\n-------------------------------------------------------------------------------\n'
 
 # Configure Poetry
 if [ "$os" == "Windows" ]; then
-    ln -s "$HOME/.poetry/bin/poetry.bat" "poetry"
-    "$HOME/.poetry/bin/poetry.bat" config virtualenvs.create "$venv_create"
-    "$HOME/.poetry/bin/poetry.bat" config virtualenvs.in-project "$venv_in_project"
-    "$HOME/.poetry/bin/poetry.bat" config virtualenvs.path "$venv_path"
+  ln -s "$HOME/.poetry/bin/poetry.bat" "poetry"
+  "$HOME/.poetry/bin/poetry.bat" config virtualenvs.create "$venv_create"
+  "$HOME/.poetry/bin/poetry.bat" config virtualenvs.in-project "$venv_in_project"
+  "$HOME/.poetry/bin/poetry.bat" config virtualenvs.path "$venv_path"
 else
-    source "$HOME"/.poetry/env
-    poetry config virtualenvs.create "$venv_create"
-    poetry config virtualenvs.in-project "$venv_in_project"
-    poetry config virtualenvs.path "$venv_path"
+  source "$HOME"/.poetry/env
+  poetry config virtualenvs.create "$venv_create"
+  poetry config virtualenvs.in-project "$venv_in_project"
+  poetry config virtualenvs.path "$venv_path"
 fi

--- a/scripts/v1.1/main.sh
+++ b/scripts/v1.1/main.sh
@@ -8,38 +8,38 @@ venv_path=$4
 
 # Define OS specific help text
 if [ "$os" == "Windows" ]; then
-  conf="\033[33mConfiguring Poetry for Windows!\033[0m"
-  act="source .venv/scripts/activate"
-  echo "VENV=.venv/scripts/activate" >> "$GITHUB_ENV"
+    conf="\033[33mConfiguring Poetry for Windows!\033[0m"
+    act="source .venv/scripts/activate"
+    echo "VENV=.venv/scripts/activate" >>"$GITHUB_ENV"
 else
-  conf="\033[33mConfiguring Poetry!\033[0m"
-  act="source .venv/bin/activate"
-  echo "VENV=.venv/bin/activate" >> "$GITHUB_ENV"
+    conf="\033[33mConfiguring Poetry!\033[0m"
+    act="source .venv/bin/activate"
+    echo "VENV=.venv/bin/activate" >>"$GITHUB_ENV"
 fi
 
 # Echo help texts
 echo -e "\n\n-------------------------------------------------------------------------------\n\n$conf 🎉"
 if [ "$venv_create" == true ] || [ "$venv_create" == "true" ]; then
-  # If user is creating a venv in-project we tell them how to activate venv
-  echo -e "\n\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'\033[0m"
-  echo -e "\n\033[33mIf you're running this in an OS matrix, use 'source \$VENV'\033[0m"
+    # If user is creating a venv in-project we tell them how to activate venv
+    echo -e "\n\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'\033[0m"
+    echo -e "\n\033[33mIf you're running this in an OS matrix, use 'source \$VENV'\033[0m"
 fi
 if [ "$os" == "Windows" ]; then
-  # If $SHELL isn't some variation of bash, output a yellow-texted warning
-  echo -e "\n\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
-  echo -e "\n\033[33mSee the package docs for more information and examples.\033[0m"
+    # If $SHELL isn't some variation of bash, output a yellow-texted warning
+    echo -e "\n\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
+    echo -e "\n\033[33mSee the package docs for more information and examples.\033[0m"
 fi
 echo -e '\n-------------------------------------------------------------------------------\n'
 
 # Configure Poetry
 if [ "$os" == "Windows" ]; then
-  ln -s "$HOME/.poetry/bin/poetry.bat" "poetry"
-  "$HOME/.poetry/bin/poetry.bat" config virtualenvs.create "$venv_create"
-  "$HOME/.poetry/bin/poetry.bat" config virtualenvs.in-project "$venv_in_project"
-  "$HOME/.poetry/bin/poetry.bat" config virtualenvs.path "$venv_path"
+    ln -s "$HOME/.poetry/bin/poetry.bat" "poetry"
+    "$HOME/.poetry/bin/poetry.bat" config virtualenvs.create "$venv_create"
+    "$HOME/.poetry/bin/poetry.bat" config virtualenvs.in-project "$venv_in_project"
+    "$HOME/.poetry/bin/poetry.bat" config virtualenvs.path "$venv_path"
 else
-  source "$HOME"/.poetry/env
-  poetry config virtualenvs.create "$venv_create"
-  poetry config virtualenvs.in-project "$venv_in_project"
-  poetry config virtualenvs.path "$venv_path"
+    source "$HOME"/.poetry/env
+    poetry config virtualenvs.create "$venv_create"
+    poetry config virtualenvs.in-project "$venv_in_project"
+    poetry config virtualenvs.path "$venv_path"
 fi

--- a/scripts/v1.2/main.sh
+++ b/scripts/v1.2/main.sh
@@ -11,9 +11,9 @@ installation_script=$6
 # Set path for each OS - done because Poetry inference is inconsistent
 # on mac-runners, and we need to know the install path so we can add it to $GITHUB_PATH
 if [ "$os" == "Windows" ]; then
-  path="C:/Users/runneradmin/AppData/Roaming/Python/Scripts/"
+    path="C:/Users/runneradmin/AppData/Roaming/Python/Scripts/"
 else
-  path="$HOME/.local/"
+    path="$HOME/.local/"
 fi
 
 # Install Poetry
@@ -25,39 +25,39 @@ export PATH="$path/bin:$PATH"
 
 # Configure Poetry
 if [ "$os" == "Windows" ]; then
-  # Adding to path on windows doesn't immediately take effect
-  # so calling the executable directly here - should be available
-  # in next steps regardless.
-  "$path/bin/poetry.exe" config virtualenvs.create "$venv_create"
-  "$path/bin/poetry.exe" config virtualenvs.in-project "$venv_in_project"
-  "$path/bin/poetry.exe" config virtualenvs.path "$venv_path"
+    # Adding to path on windows doesn't immediately take effect
+    # so calling the executable directly here - should be available
+    # in next steps regardless.
+    "$path/bin/poetry.exe" config virtualenvs.create "$venv_create"
+    "$path/bin/poetry.exe" config virtualenvs.in-project "$venv_in_project"
+    "$path/bin/poetry.exe" config virtualenvs.path "$venv_path"
 else
-  poetry config virtualenvs.create "$venv_create"
-  poetry config virtualenvs.in-project "$venv_in_project"
-  poetry config virtualenvs.path "$venv_path"
+    poetry config virtualenvs.create "$venv_create"
+    poetry config virtualenvs.in-project "$venv_in_project"
+    poetry config virtualenvs.path "$venv_path"
 fi
 
 # Define OS specific help texts
 if [ "$os" == "Windows" ]; then
-  conf="\033[33mConfiguring Poetry for Windows!\033[0m"
-  act="source .venv/scripts/activate"
-  echo "VENV=.venv/scripts/activate" >>"$GITHUB_ENV"
+    conf="\033[33mConfiguring Poetry for Windows!\033[0m"
+    act="source .venv/scripts/activate"
+    echo "VENV=.venv/scripts/activate" >>"$GITHUB_ENV"
 else
-  conf="\033[33mConfiguring Poetry!\033[0m"
-  act="source .venv/bin/activate"
-  echo "VENV=.venv/bin/activate" >>"$GITHUB_ENV"
+    conf="\033[33mConfiguring Poetry!\033[0m"
+    act="source .venv/bin/activate"
+    echo "VENV=.venv/bin/activate" >>"$GITHUB_ENV"
 fi
 
 # Output help texts
 echo -e "\n\n-------------------------------------------------------------------------------\n\n$conf 🎉"
 if [ "$venv_create" == true ] || [ "$venv_create" == "true" ]; then
-  # If user is creating a venv in-project we tell them how to activate venv
-  echo -e "\n\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'\033[0m"
-  echo -e "\n\033[33mIf you're running this in an OS matrix, use 'source \$VENV'\033[0m"
+    # If user is creating a venv in-project we tell them how to activate venv
+    echo -e "\n\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'\033[0m"
+    echo -e "\n\033[33mIf you're running this in an OS matrix, use 'source \$VENV'\033[0m"
 fi
 if [ "$os" == "Windows" ]; then
-  # If $SHELL isn't some variation of bash, output a yellow-texted warning
-  echo -e "\n\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
-  echo -e "\n\033[33mSee the github action docs for more information and examples.\033[0m"
+    # If $SHELL isn't some variation of bash, output a yellow-texted warning
+    echo -e "\n\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
+    echo -e "\n\033[33mSee the github action docs for more information and examples.\033[0m"
 fi
 echo -e '\n-------------------------------------------------------------------------------\n'

--- a/scripts/v1.2/main.sh
+++ b/scripts/v1.2/main.sh
@@ -11,9 +11,9 @@ installation_script=$6
 # Set path for each OS - done because Poetry inference is inconsistent
 # on mac-runners, and we need to know the install path so we can add it to $GITHUB_PATH
 if [ "$os" == "Windows" ]; then
-    path="C:/Users/runneradmin/AppData/Roaming/Python/Scripts/"
+  path="C:/Users/runneradmin/AppData/Roaming/Python/Scripts/"
 else
-    path="$HOME/.local/"
+  path="$HOME/.local/"
 fi
 
 # Install Poetry
@@ -25,39 +25,39 @@ export PATH="$path/bin:$PATH"
 
 # Configure Poetry
 if [ "$os" == "Windows" ]; then
-    # Adding to path on windows doesn't immediately take effect
-    # so calling the executable directly here - should be available
-    # in next steps regardless.
-    "$path/bin/poetry.exe" config virtualenvs.create "$venv_create"
-    "$path/bin/poetry.exe" config virtualenvs.in-project "$venv_in_project"
-    "$path/bin/poetry.exe" config virtualenvs.path "$venv_path"
+  # Adding to path on windows doesn't immediately take effect
+  # so calling the executable directly here - should be available
+  # in next steps regardless.
+  "$path/bin/poetry.exe" config virtualenvs.create "$venv_create"
+  "$path/bin/poetry.exe" config virtualenvs.in-project "$venv_in_project"
+  "$path/bin/poetry.exe" config virtualenvs.path "$venv_path"
 else
-    poetry config virtualenvs.create "$venv_create"
-    poetry config virtualenvs.in-project "$venv_in_project"
-    poetry config virtualenvs.path "$venv_path"
+  poetry config virtualenvs.create "$venv_create"
+  poetry config virtualenvs.in-project "$venv_in_project"
+  poetry config virtualenvs.path "$venv_path"
 fi
 
 # Define OS specific help texts
 if [ "$os" == "Windows" ]; then
-    conf="\033[33mConfiguring Poetry for Windows!\033[0m"
-    act="source .venv/scripts/activate"
-    echo "VENV=.venv/scripts/activate" >>"$GITHUB_ENV"
+  conf="\033[33mConfiguring Poetry for Windows!\033[0m"
+  act="source .venv/scripts/activate"
+  echo "VENV=.venv/scripts/activate" >>"$GITHUB_ENV"
 else
-    conf="\033[33mConfiguring Poetry!\033[0m"
-    act="source .venv/bin/activate"
-    echo "VENV=.venv/bin/activate" >>"$GITHUB_ENV"
+  conf="\033[33mConfiguring Poetry!\033[0m"
+  act="source .venv/bin/activate"
+  echo "VENV=.venv/bin/activate" >>"$GITHUB_ENV"
 fi
 
 # Output help texts
 echo -e "\n\n-------------------------------------------------------------------------------\n\n$conf 🎉"
 if [ "$venv_create" == true ] || [ "$venv_create" == "true" ]; then
-    # If user is creating a venv in-project we tell them how to activate venv
-    echo -e "\n\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'\033[0m"
-    echo -e "\n\033[33mIf you're running this in an OS matrix, use 'source \$VENV'\033[0m"
+  # If user is creating a venv in-project we tell them how to activate venv
+  echo -e "\n\n\033[33mIf you are creating a venv in your project, you can activate it by running '$act'\033[0m"
+  echo -e "\n\033[33mIf you're running this in an OS matrix, use 'source \$VENV'\033[0m"
 fi
 if [ "$os" == "Windows" ]; then
-    # If $SHELL isn't some variation of bash, output a yellow-texted warning
-    echo -e "\n\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
-    echo -e "\n\033[33mSee the github action docs for more information and examples.\033[0m"
+  # If $SHELL isn't some variation of bash, output a yellow-texted warning
+  echo -e "\n\n\033[33mMake sure to set your default shell to bash when on Windows.\033[0m"
+  echo -e "\n\033[33mSee the github action docs for more information and examples.\033[0m"
 fi
 echo -e '\n-------------------------------------------------------------------------------\n'


### PR DESCRIPTION
Adds `shfmt` and `shellcheck` to our linter setup. Only the `${INSTALLATION_ARGUMENTS}` call in `main.sh:20` looks like it cannot be formatted according to shellcheck, so I've added ignore statements for those. This mainly re-formats the old script files. 

Also sets `set -eo pipefail` to make the action error properly. The "command poetry does not exist" output for when the installation failed is not very user friendly.