### PR TITLE
Update Python and Poetry test matrix versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,13 @@ on: pull_request
 
 env:
   # JSON variables (used in our strategy/matrix)
-  SUPPORTED_POETRY_VERSIONS: '\"poetry-version\":[\"1.1.14\", \"1.2.1\"]'
-  SUPPORTED_PYTHON_VERSIONS: '\"python-version\":[\"3.7\", \"3.10\", \"3.11.0-rc.1\"]'
+  SUPPORTED_POETRY_VERSIONS: '\"poetry-version\":[\"1.1.14\", \"1.2.2\"]'
+  SUPPORTED_PYTHON_VERSIONS: '\"python-version\":[\"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11.0-rc.2\"]'
   SUPPORTED_OPERATING_SYSTEMS: '\"os\":[\"ubuntu-latest\", \"macos-latest\", \"windows-latest\"]'
 
   # Normal variables (used in steps/*)
   LATEST_PYTHON: "3.10"
-  LATEST_POETRY: "1.2.1"
+  LATEST_POETRY: "1.2.2"
 
 jobs:
   # The set-env job translates our json variables to a format we


### PR DESCRIPTION
Adds back Python 3.8 and 3.9, and updates the 3.11 release candidate. Poetry 1.2.2 was also just released.