### PR TITLE
Resolve windows 3.8 issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ defaults:
     shell: bash
 
 jobs:
+
   # Make sure the action works using the default settings
   test-install:
     name: default ${{ matrix.poetry-version }} ${{ matrix.os }} ${{ matrix.python-version }}
@@ -38,12 +39,13 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2" ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "${{ matrix.python-version }}"
       - uses: ./
         with:
           version: 1.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
   # Make sure the action sets config options correctly
   test-config-options:
-    name: Set non-standard config options - ${{ matrix.os }}
+    name: non-standard config - ${{ matrix.os }} ${{ matrix.python-version }}
     strategy:
       fail-fast: true
       matrix:

--- a/main.sh
+++ b/main.sh
@@ -8,7 +8,12 @@ YELLOW="\033[33m"
 RESET="\033[0m"
 
 INSTALLATION_SCRIPT="$(mktemp)"
-curl -sSL https://install.python-poetry.org/ --output "$INSTALLATION_SCRIPT"
+
+if [ "${RUNNER_OS}" == "Windows" ]; then
+  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py --output "$INSTALLATION_SCRIPT"
+else
+  curl -sSL https://install.python-poetry.org/ --output "$INSTALLATION_SCRIPT"
+fi
 
 echo -e "\n${YELLOW}Setting Poetry installation path as $INSTALL_PATH${RESET}\n"
 echo -e "${YELLOW}Installing Poetry 👷${RESET}\n"


### PR DESCRIPTION
Adds the Python matrix to the non-default settings test. This would have uncovered the issue from #94. Then it resolves #94 by avoiding the official installation script for Windows targets. 

A few things to consider:
- It would have been nice to limit the logic to Windows for Python <= 3.8, but we cannot reliably know what Python version is active, can we? I believe using `setup-python` after this action works most of the time, if not all of the time.
- This just reverts to the old installation script. Are there any reasons to consider using a newer version of it?