### PR TITLE
added quotes around python version in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
@@ -266,7 +266,7 @@ jobs:
       - uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: 3.10
+          python-version: '3.10'
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
@@ -370,7 +370,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
@@ -486,7 +486,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Load cached Poetry installation
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
I got an error running the example code:

  Version 3.1 was not found in the local cache
  Error: Version 3.1 with arch x64 not found

It basically treated the python version 3.10 as a float which is equivalent to 3.1 which cannot be found. I added the quotation marks to make sure it is treated as a string.