### PR TITLE
fix: solve permission denied when running with act

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Install Poetry Action"
+name: "Install Poetry Action - act fix"
 author: "Sondre Lillebø Gundersen <sondrelg@live.no>"
 description: "Installs and configures Poetry"
 branding:
@@ -32,7 +32,9 @@ runs:
   using: "composite"
   steps:
     - name: Install and configure Poetry
-      run: $GITHUB_ACTION_PATH/main.sh
+      run: |
+        chmod +x $GITHUB_ACTION_PATH/main.sh
+        bash $GITHUB_ACTION_PATH/main.sh
       shell: bash
       env:
         VERSION:                ${{ inputs.version }}


### PR DESCRIPTION
When testing the action locally using [act](https://github.com/nektos/act), it returns

`/var/run/act/workflow/1-composite-0.sh: line 2: /var/run/act/actions/snok-install-poetry@v1.3.3/main.sh: Permission denied`

This commit fixes the issue by setting the execution permission on the main installer script