### PR TITLE
codecov/codecov-action@v1 is deprecated; v3 is now recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ jobs:
       # (requires CODECOV_TOKEN in repository secrets)
       #----------------------------------------------
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}  # Only required for private repositories
           file: ./coverage.xml


### PR DESCRIPTION
I was setting up your action with coverage and came across this [deprecation](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1).

