### PR TITLE
Fix permission denied on windows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
   using: "composite"
   steps:
     - name: Install and configure Poetry
-      run: $GITHUB_ACTION_PATH/main.sh
+      run: bash $GITHUB_ACTION_PATH/main.sh
       shell: bash
       env:
         VERSION:                ${{ inputs.version }}


### PR DESCRIPTION
I'm not sure if this fixes any error on windows when using github actions directly, but this fixes the following error when using netkos/act

This error happens with bash as default run.

```bash
[Python Packaging/Test-4]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2-composite-0.sh] user= workdir=
| /var/run/act/workflow/2-composite-0.sh: line 2: /var/run/act/actions/snok-install-poetry@master/main.sh: Permission denied
[Python Packaging/Test-4]   ❌  Failure - Main Install and configure Poetry
```

`/var/run/act/workflow/2-composite-0.sh` contains `$GITHUB_ACTIONS_PATH/main.sh`

Maybe this should be done differently, but the script is not executable so the shebang doesnt work.