### PR TITLE
Remove `curl` dependency

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -8,11 +8,12 @@ YELLOW="\033[33m"
 RESET="\033[0m"
 
 INSTALLATION_SCRIPT="$(mktemp)"
+GET_SCRIPT_CMD="python -c 'import urllib.request, sys; print(urllib.request.urlopen(f\"{sys.argv[1]}\").read().decode(\"utf8\"))'"
 
 if [ "${RUNNER_OS}" == "Windows" ]; then
-  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py --output "$INSTALLATION_SCRIPT"
+  "${GET_SCRIPT_CMD}" https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py > "$INSTALLATION_SCRIPT"
 else
-  curl -sSL https://install.python-poetry.org/ --output "$INSTALLATION_SCRIPT"
+  "${GET_SCRIPT_CMD}" https://install.python-poetry.org/ > "$INSTALLATION_SCRIPT"
 fi
 
 echo -e "\n${YELLOW}Setting Poetry installation path as $INSTALL_PATH${RESET}\n"

--- a/main.sh
+++ b/main.sh
@@ -11,9 +11,9 @@ INSTALLATION_SCRIPT="$(mktemp)"
 GET_SCRIPT_CMD="python3 -c 'import urllib.request, sys; print(urllib.request.urlopen(f\"{sys.argv[1]}\").read().decode(\"utf8\"))'"
 
 if [ "${RUNNER_OS}" == "Windows" ]; then
-  "${GET_SCRIPT_CMD}" https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py > "$INSTALLATION_SCRIPT"
+  ${GET_SCRIPT_CMD} https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py > "$INSTALLATION_SCRIPT"
 else
-  "${GET_SCRIPT_CMD}" https://install.python-poetry.org/ > "$INSTALLATION_SCRIPT"
+  ${GET_SCRIPT_CMD} https://install.python-poetry.org/ > "$INSTALLATION_SCRIPT"
 fi
 
 echo -e "\n${YELLOW}Setting Poetry installation path as $INSTALL_PATH${RESET}\n"

--- a/main.sh
+++ b/main.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 download_script() {
-    python -c 'import urllib.request, sys; print(urllib.request.urlopen(f"{sys.argv[1]}").read().decode("utf8"))' $1
+  python -c 'import urllib.request, sys; print(urllib.request.urlopen(f"{sys.argv[1]}").read().decode("utf8"))' $1
 }
 
 INSTALL_PATH="${POETRY_HOME:-$HOME/.local}"
@@ -14,9 +14,9 @@ RESET="\033[0m"
 INSTALLATION_SCRIPT="$(mktemp)"
 
 if [ "${RUNNER_OS}" == "Windows" ]; then
-  download_script https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py > "$INSTALLATION_SCRIPT"
+  download_script https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py >"$INSTALLATION_SCRIPT"
 else
-  download_script https://install.python-poetry.org/ > "$INSTALLATION_SCRIPT"
+  download_script https://install.python-poetry.org/ >"$INSTALLATION_SCRIPT"
 fi
 
 echo -e "\n${YELLOW}Setting Poetry installation path as $INSTALL_PATH${RESET}\n"

--- a/main.sh
+++ b/main.sh
@@ -2,18 +2,21 @@
 
 set -eo pipefail
 
+download_script() {
+    python -c 'import urllib.request, sys; print(urllib.request.urlopen(f"{sys.argv[1]}").read().decode("utf8"))' $1
+}
+
 INSTALL_PATH="${POETRY_HOME:-$HOME/.local}"
 
 YELLOW="\033[33m"
 RESET="\033[0m"
 
 INSTALLATION_SCRIPT="$(mktemp)"
-GET_SCRIPT_CMD="python3 -c 'import urllib.request, sys; print(urllib.request.urlopen(f\"{sys.argv[1]}\").read().decode(\"utf8\"))'"
 
 if [ "${RUNNER_OS}" == "Windows" ]; then
-  ${GET_SCRIPT_CMD} https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py > "$INSTALLATION_SCRIPT"
+  download_script https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py > "$INSTALLATION_SCRIPT"
 else
-  ${GET_SCRIPT_CMD} https://install.python-poetry.org/ > "$INSTALLATION_SCRIPT"
+  download_script https://install.python-poetry.org/ > "$INSTALLATION_SCRIPT"
 fi
 
 echo -e "\n${YELLOW}Setting Poetry installation path as $INSTALL_PATH${RESET}\n"

--- a/main.sh
+++ b/main.sh
@@ -8,7 +8,7 @@ YELLOW="\033[33m"
 RESET="\033[0m"
 
 INSTALLATION_SCRIPT="$(mktemp)"
-GET_SCRIPT_CMD="python -c 'import urllib.request, sys; print(urllib.request.urlopen(f\"{sys.argv[1]}\").read().decode(\"utf8\"))'"
+GET_SCRIPT_CMD="python3 -c 'import urllib.request, sys; print(urllib.request.urlopen(f\"{sys.argv[1]}\").read().decode(\"utf8\"))'"
 
 if [ "${RUNNER_OS}" == "Windows" ]; then
   "${GET_SCRIPT_CMD}" https://raw.githubusercontent.com/python-poetry/poetry/48339106eb0d403a3c66519317488c8185844b32/install-poetry.py > "$INSTALLATION_SCRIPT"


### PR DESCRIPTION
Thanks for the amazing GitHub Action! 

This PR removes `curl` usage from the script and replaces it with `python3`. Many hosted GitHub Action runners don't have `curl` by default, so they are required to install it before using this action. This PR ensures that the installation of `curl` is not needed.