### PR TITLE
Use `python3` instead of `python`

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 download_script() {
-  python -c 'import urllib.request, sys; print(urllib.request.urlopen(f"{sys.argv[1]}").read().decode("utf8"))' $1
+  python3 -c 'import urllib.request, sys; print(urllib.request.urlopen(f"{sys.argv[1]}").read().decode("utf8"))' $1
 }
 
 INSTALL_PATH="${POETRY_HOME:-$HOME/.local}"


### PR DESCRIPTION
**Problem:** A recent change https://github.com/snok/install-poetry/pull/153 removed `curl` usage from the script and replaced it with `python`. The justification is that script already relies on Python being present. However, it relies specifically on `python3`, not `python`. As reported in https://github.com/snok/install-poetry/issues/158, calling `python` errors out on some setups:

```
/home/runner/_work/_actions/snok/install-poetry/v1/main.sh: line 6: python: command not found
```

**Solution:** Use `python3` instead of `python`.